### PR TITLE
lightning-utilities 0.7.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/lightning-utilities-{{ version }}.tar.gz
-  sha256: 6f02cfe59e6576487e709a0e66e07671563bde9e21b40e1c567918e4d753278c
+  sha256: 9748a5466490d6e45c2df60c1ee77ff37a1a660ea6313bc0832ab7317a081cef
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "lightning-utilities" %}
-{% set version = "0.6.0.post0" %}
+{% set version = "0.7.1" %}
 
 package:
   name: {{ name|lower }}
@@ -10,32 +10,40 @@ source:
   sha256: 6f02cfe59e6576487e709a0e66e07671563bde9e21b40e1c567918e4d753278c
 
 build:
-  script: {{ PYTHON }} -m pip install . -vv
   number: 0
-  noarch: python
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:
   host:
-    - python >=3.8
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.8
-    - packaging >=20.0
+    - python
+    - importlib-metadata >=4.0.0  # [py<38]
+    - packaging >=17.1
     - typing_extensions
 
 test:
   imports:
     - lightning_utilities
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/Lightning-AI/utilities
   summary: PyTorch Lightning Sample project.
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
+  description: |
+    Common Python utilities and GitHub Actions in Lightning Ecosystem.
+  dev_url: https://github.com/Lightning-AI/utilities
+  doc_url: https://github.com/Lightning-AI/utilities
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Changelog: https://github.com/Lightning-AI/lightning/releases
License: https://github.com/Lightning-AI/lightning/blob/1.9.3/LICENSE
Requirements: 
- https://github.com/Lightning-AI/lightning/blob/1.9.3/pyproject.toml
- https://github.com/Lightning-AI/lightning/blob/1.9.3/requirements/pytorch/base.txt
- https://github.com/Lightning-AI/lightning/blob/1.9.3/requirements.txt
- https://github.com/Lightning-AI/lightning/blob/1.9.3/setup.py


Actions:
1. Skip `py<37`
2. Add `--no-dep`s to script
3. Add missing `setuptools`, `wheel` to `host`
4. Add `importlib-metadata >=4.0.0  # [py<38]` to `run`
5. Fix `python` pinnings
6. Fix `packaging` pinning
7. Add `license_family`
8. Add `description`
9. Add dev and doc urls